### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#d573118`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -825,12 +825,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "025d1d15b3d612deda2ff7d026afa6f7f1379411"
+                "reference": "d573118708d6ec7ecaa2189d7c06a00c9226a16e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/025d1d15b3d612deda2ff7d026afa6f7f1379411",
-                "reference": "025d1d15b3d612deda2ff7d026afa6f7f1379411",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d573118708d6ec7ecaa2189d7c06a00c9226a16e",
+                "reference": "d573118708d6ec7ecaa2189d7c06a00c9226a16e",
                 "shasum": ""
             },
             "require": {
@@ -987,7 +987,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T16:38:56+00:00"
+            "time": "2025-09-11T18:12:00+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#025d1d1` to `dev-main#d573118`.

This pull request changes the following file(s): 

- Update `composer.lock`