### PR TITLE
Update ghostwriter/coding-standard to version dev-main#4c9bc3e

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,14 +36,14 @@
     ],
     "require": {
         "php": "~8.4.0 || ~8.5.0",
-        "ghostwriter/option": "^2.0.0"
+        "ghostwriter/option": "~2.0.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c336b794f22dc21628281543d7853cdc",
+    "content-hash": "3ed25a6203688492248f96dc6b00e3dd",
     "packages": [
         {
             "name": "ghostwriter/option",
@@ -825,12 +825,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8"
+                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5a3b19053dc74511910d5f81bb41e8422c6842c8",
-                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4c9bc3e55140d0c376a3a68f561f7164699e8225",
+                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225",
                 "shasum": ""
             },
             "require": {
@@ -880,7 +880,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
-                "phpunit/phpunit": "~12.3.11",
+                "phpunit/phpunit": "~12.3.12",
                 "symfony/var-dumper": "~7.3.3"
             },
             "default-branch": true,
@@ -987,7 +987,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-19T12:54:01+00:00"
+            "time": "2025-09-21T13:20:26+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#5a3b190` to `dev-main#4c9bc3e`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`