### PR TITLE
Update boundwize/structarmed to version 0.6.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.5",
+        "boundwize/structarmed": "^0.6.6",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3825b7c98dad66182eeecd2fbe5de7f2",
+    "content-hash": "05cde82004f6b4aa85a98522549bea38",
     "packages": [
         {
             "name": "ghostwriter/option",
@@ -68,16 +68,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66"
+                "reference": "7c8221644ea04f476d328a29ea4d9bbce9933ce8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66",
-                "reference": "3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7c8221644ea04f476d328a29ea4d9bbce9933ce8",
+                "reference": "7c8221644ea04f476d328a29ea4d9bbce9933ce8",
                 "shasum": ""
             },
             "require": {
@@ -126,7 +126,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.5"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.6"
             },
             "funding": [
                 {
@@ -134,7 +134,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-17T03:44:56+00:00"
+            "time": "2026-05-17T23:55:12+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -203,16 +203,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "43b9a51ce715249094aac7e9b6e2b4e5450d2caa"
+                "reference": "d3e21d2b86352460983d1bb9ffc67b78a289e468"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/43b9a51ce715249094aac7e9b6e2b4e5450d2caa",
-                "reference": "43b9a51ce715249094aac7e9b6e2b4e5450d2caa",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d3e21d2b86352460983d1bb9ffc67b78a289e468",
+                "reference": "d3e21d2b86352460983d1bb9ffc67b78a289e468",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.5",
+                "boundwize/structarmed": "^0.6.6",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -323,7 +323,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-17T11:12:21+00:00"
+            "time": "2026-05-18T00:18:19+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.5` to `0.6.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`