### PR TITLE
Update boundwize/structarmed to version 0.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.10",
+        "boundwize/structarmed": "^0.7.11",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed4d3bd91edd5a8974bf96b2dd255879",
+    "content-hash": "c9c521eca78e197b3b199889c3a1fd2e",
     "packages": [
         {
             "name": "ghostwriter/option",
@@ -68,16 +68,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.10",
+            "version": "0.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d"
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/35c3929ce13f726ae5384773d7272fc402b0366d",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
                 "shasum": ""
             },
             "require": {
@@ -130,7 +130,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.10"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.11"
             },
             "funding": [
                 {
@@ -138,7 +138,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T12:23:38+00:00"
+            "time": "2026-05-25T22:59:15+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -296,16 +296,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "2bdc20814da0fd448a4edf5c5250b581d73cf88f"
+                "reference": "d83e0d58c5b03742f8ee5f9a347281978dfaf4fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2bdc20814da0fd448a4edf5c5250b581d73cf88f",
-                "reference": "2bdc20814da0fd448a4edf5c5250b581d73cf88f",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d83e0d58c5b03742f8ee5f9a347281978dfaf4fe",
+                "reference": "d83e0d58c5b03742f8ee5f9a347281978dfaf4fe",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.10",
+                "boundwize/structarmed": "^0.7.11",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -416,7 +416,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T20:46:31+00:00"
+            "time": "2026-05-26T00:11:34+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.10` to `0.7.11`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`